### PR TITLE
Retain parameters in user-facing panels between instantiations

### DIFF
--- a/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/CoherenceFeaturePlugin.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/CoherenceFeaturePlugin.java
@@ -69,7 +69,7 @@ public class CoherenceFeaturePlugin extends AbstractInteractivePlugin<BufferedIm
 	public CoherenceFeaturePlugin(final ImageRegionStore<BufferedImage> regionServer) {
 		this.regionStore = regionServer;
 		
-		params = new ParameterList().
+		params = new ParameterList(getName()).
 				addDoubleParameter("magnification", "Magnification", 5).
 				addChoiceParameter("stainChoice", "Stains", "Optical density", new String[]{"Optical density", "H-DAB", "H&E", "H-DAB (8-bit)", "H&E (8-bit)", "RGB", "Grayscale"});
 		

--- a/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/HaralickFeaturesPlugin.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/HaralickFeaturesPlugin.java
@@ -90,7 +90,7 @@ public class HaralickFeaturesPlugin extends AbstractInteractivePlugin<BufferedIm
 	public HaralickFeaturesPlugin(final ImageRegionStore<BufferedImage> regionServer) {
 		this.regionStore = regionServer;
 		
-		params = new ParameterList().
+		params = new ParameterList(getName()).
 				addDoubleParameter("downsample", "Downsample", 1, null, "Amount to downsample the image before calculating textures; choose 1 to use full resolution, or a higher value to use a smaller image").
 				addDoubleParameter("magnification", "Magnification", 5, null, "Magnification factor of the image used to calculate the textures").
 				addDoubleParameter("pixelSizeMicrons", "Preferred pixel size", 2, GeneralTools.micrometerSymbol(), "Preferred pixel size of the image used to calculate the tetures - higher values means coarser (lower resolution) images").

--- a/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/IntensityFeaturesPlugin.java
@@ -612,7 +612,7 @@ public class IntensityFeaturesPlugin extends AbstractInteractivePlugin<BufferedI
 		
 		if (!parametersInitialized) {
 			
-			params = new ParameterList();
+			params = new ParameterList(getName());
 			
 			// Regions & resolution
 			params.addTitleParameter("Resolution");

--- a/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/LocalBinaryPatternsPlugin.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/LocalBinaryPatternsPlugin.java
@@ -70,7 +70,7 @@ public class LocalBinaryPatternsPlugin extends AbstractInteractivePlugin<Buffere
 	public LocalBinaryPatternsPlugin(final ImageRegionStore<BufferedImage> regionServer) {
 		this.regionStore = regionServer;
 		
-		params = new ParameterList().
+		params = new ParameterList(getName()).
 				addDoubleParameter("magnification", "Magnification", 5).
 				addChoiceParameter("stainChoice", "Stains", "Optical density", new String[]{"Optical density", "H-DAB", "H&E", "H-DAB (8-bit)", "H&E (8-bit)", "RGB", "Grayscale"});
 		

--- a/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/TilerPlugin.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/algorithms/TilerPlugin.java
@@ -57,7 +57,7 @@ public class TilerPlugin<T> extends AbstractDetectionPlugin<T> {
 
 	public TilerPlugin() {
 		// Set up initial parameters
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		
 		params.addTitleParameter("Tile options");
 		params.addDoubleParameter("tileSizeMicrons", "Tile size", 100, GeneralTools.micrometerSymbol(), "Specify tile width and height, in " + GeneralTools.micrometerSymbol());

--- a/qupath-core-processing-awt/src/main/java/qupath/lib/analysis/objects/TileClassificationsToAnnotationsPlugin.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/analysis/objects/TileClassificationsToAnnotationsPlugin.java
@@ -131,7 +131,7 @@ public class TileClassificationsToAnnotationsPlugin<T> extends AbstractDetection
 			choices.add(0, allClasses);
 //			PathClass classTumor = PathClassFactory.getDefaultPathClass(PathClasses.TUMOR); // Tumor is the most likely choice, so default to it if available
 //			PathClass defaultChoice = choices.contains(classTumor) ? classTumor : choices.get(0);
-			params = new ParameterList();
+			params = new ParameterList(getName());
 			
 			params.addChoiceParameter("pathClass", "Choose class", defaultChoice, choices, "Choose PathClass to create annotations from")
 					.addBooleanParameter("deleteTiles", "Delete existing child objects", false, "Delete the tiles that were used for creating annotations - further training will not be possible after these are deleted")

--- a/qupath-core-processing-awt/src/main/java/qupath/lib/plugins/objects/DilateAnnotationPlugin.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/plugins/objects/DilateAnnotationPlugin.java
@@ -52,7 +52,7 @@ import qupath.lib.roi.interfaces.ROI;
  */
 public class DilateAnnotationPlugin<T> extends AbstractInteractivePlugin<T> {
 	
-	private ParameterList params = new ParameterList()
+	private ParameterList params = new ParameterList(getName())
 			.addDoubleParameter("radiusMicrons", "Expansion radius", 100, GeneralTools.micrometerSymbol(), "Distance to expand ROI")
 			.addDoubleParameter("radiusPixels", "Expansion radius", 100, "px", "Distance to expand ROI")
 			.addBooleanParameter("removeInterior", "Remove interior", false, "Create annotation containing only the expanded region, with the original ROI removed")

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FindConvexHullDetectionsPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/FindConvexHullDetectionsPlugin.java
@@ -128,7 +128,7 @@ public class FindConvexHullDetectionsPlugin<T> extends AbstractInteractivePlugin
 
 	@Override
 	public ParameterList getDefaultParameterList(ImageData<T> imageData) {
-		return new ParameterList()
+		return new ParameterList(getName())
 				.addIntParameter("nIterations", "Number of iterations", 10, null, "Number of times to iteratively identify detections from the convex hull of the detection centroids")
 				.addBooleanParameter("deleteImmediately", "Delete immediately", false, "Immediately delete detections, rather than selecting them only");
 	}

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/ShapeFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/ShapeFeaturesPlugin.java
@@ -59,7 +59,7 @@ public class ShapeFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 	
 	public ShapeFeaturesPlugin() {
 		
-		params = new ParameterList()
+		params = new ParameterList(getName())
 				.addTitleParameter("Measurements")
 				.addBooleanParameter("area", "Area", true, "Compute area of ROI")
 				.addBooleanParameter("perimeter", "Perimeter", false, "Compute perimeter of ROI")

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/objects/SmoothFeaturesPlugin.java
@@ -68,7 +68,7 @@ public class SmoothFeaturesPlugin<T> extends AbstractInteractivePlugin<T> {
 	final private static Logger logger = LoggerFactory.getLogger(SmoothFeaturesPlugin.class);
 	
 	public SmoothFeaturesPlugin() {
-		params = new ParameterList()
+		params = new ParameterList(getName())
 				.addDoubleParameter("fwhmMicrons", "Radius (FWHM)", 25, GeneralTools.micrometerSymbol(), "Smoothing filter size - higher values indicate more smoothing")
 				.addDoubleParameter("fwhmPixels", "Radius (FWHM)", 100, "pixels", "Smoothing filter size - higher values indicate more smoothing")
 				.addBooleanParameter("smoothWithinClasses", "Smooth within classes", false, "Restrict smoothing to only be applied within objects with the same base classification")

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/AbstractParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/AbstractParameter.java
@@ -23,6 +23,8 @@
 
 package qupath.lib.plugins.parameters;
 
+import java.util.prefs.Preferences;
+
 /**
  * Abstract Parameter implementation.
  * 
@@ -33,7 +35,8 @@ package qupath.lib.plugins.parameters;
 public abstract class AbstractParameter<S> implements Parameter<S> {
 
 	private static final long serialVersionUID = 1L;
-	
+
+	private String group = null;
 	private String prompt = null;
 	private S defaultValue;	
 	
@@ -41,13 +44,18 @@ public abstract class AbstractParameter<S> implements Parameter<S> {
 	private boolean hidden = false;
 	
 	protected S lastValue = null;
-	
-	AbstractParameter(String prompt, S defaultValue, S value, String helpText, boolean hidden) {
+
+	protected Preferences prefs;
+
+	AbstractParameter(String group, String prompt, S defaultValue, S value, String helpText, boolean hidden) {
+		this.group = group;
 		this.prompt = prompt;
 		this.defaultValue = defaultValue;
 		this.lastValue = value;
 		this.helpText = helpText;
 		this.hidden = hidden;
+
+		prefs = Preferences.userNodeForPackage(this.getClass()).node(group);
 	}
 	
 	@Override
@@ -64,12 +72,18 @@ public abstract class AbstractParameter<S> implements Parameter<S> {
 	public S getDefaultValue() {
 		return defaultValue;
 	}
-	
+
+	public void setDefaultValue(S defaultValue) { this.defaultValue = defaultValue; }
+
+	protected S getStoredValue() {
+		return defaultValue;
+	} // should be overridden if possible
+
 	@Override
 	public S getValue() {
 		return lastValue;
 	}
-	
+		
 	@Override
 	public void resetValue() {
 		lastValue = null;
@@ -79,9 +93,14 @@ public abstract class AbstractParameter<S> implements Parameter<S> {
 	public S getValueOrDefault() {
 		if (lastValue != null)
 			return lastValue;
-		return defaultValue;
+		return getStoredValue();
 	}
-	
+
+	@Override
+	public String getGroup() {
+		return group;
+	}
+
 	@Override
 	public String getPrompt() {
 		return prompt;

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/BooleanParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/BooleanParameter.java
@@ -37,22 +37,28 @@ public class BooleanParameter extends AbstractParameter<Boolean> {
 
 	private static final long serialVersionUID = 1L;
 
-	BooleanParameter(String prompt, Boolean defaultValue, Boolean lastValue, String helpText, boolean isHidden) {
-		super(prompt, defaultValue, lastValue, helpText, isHidden);
+	BooleanParameter(String group, String prompt, Boolean defaultValue, Boolean lastValue, String helpText, boolean isHidden) {
+		super(group, prompt, defaultValue, lastValue, helpText, isHidden);
 	}
 	
-	public BooleanParameter(String prompt, Boolean defaultValue, Boolean lastValue, String helpText) {
-		this(prompt, defaultValue, lastValue, helpText, false);
+	public BooleanParameter(String group, String prompt, Boolean defaultValue, Boolean lastValue, String helpText) {
+		this(group, prompt, defaultValue, lastValue, helpText, false);
 	}
 
-	public BooleanParameter(String prompt, Boolean defaultValue, String helpText) {
-		this(prompt, defaultValue, null, helpText);
+	public BooleanParameter(String group, String prompt, Boolean defaultValue, String helpText) {
+		this(group, prompt, defaultValue, null, helpText);
+	}
+
+	@Override
+	public Boolean getStoredValue() {
+		return prefs.getBoolean(getPrompt(), getDefaultValue());
 	}
 
 	@Override
 	public boolean setStringLastValue(Locale locale, String value) {
 		try {
 			boolean b = Boolean.parseBoolean(value);
+			prefs.putBoolean(getPrompt(), b);
 			return setValue(b);
 		} catch (Exception e) {}
 		return false;
@@ -65,7 +71,7 @@ public class BooleanParameter extends AbstractParameter<Boolean> {
 
 	@Override
 	public Parameter<Boolean> duplicate() {
-		return new BooleanParameter(getPrompt(), getDefaultValue(), getValue(), getHelpText(), isHidden());
+		return new BooleanParameter(getGroup(), getPrompt(), getDefaultValue(), getValue(), getHelpText(), isHidden());
 	}
 
 

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ChoiceParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ChoiceParameter.java
@@ -42,21 +42,21 @@ public class ChoiceParameter<S> extends AbstractParameter<S> {
 	
 	protected List<S> choices = null;
 
-	ChoiceParameter(String prompt, S defaultValue, List<S> choices, S lastValue, String helpText, boolean isHidden) {
-		super(prompt, defaultValue, lastValue, helpText, isHidden);
+	ChoiceParameter(String group, String prompt, S defaultValue, List<S> choices, S lastValue, String helpText, boolean isHidden) {
+		super(group, prompt, defaultValue, lastValue, helpText, isHidden);
 		this.choices = choices;
 	}
 
-	public ChoiceParameter(String prompt, S defaultValue, List<S> choices, S lastValue, String helpText) {
-		this(prompt, defaultValue, choices, lastValue, helpText, false);
+	public ChoiceParameter(String group, String prompt, S defaultValue, List<S> choices, S lastValue, String helpText) {
+		this(group, prompt, defaultValue, choices, lastValue, helpText, false);
 	}
 
-	public ChoiceParameter(String prompt, S defaultValue, List<S> choices, String helpText) {
-		this(prompt, defaultValue, choices, null, helpText);
+	public ChoiceParameter(String group, String prompt, S defaultValue, List<S> choices, String helpText) {
+		this(group, prompt, defaultValue, choices, null, helpText);
 	}
 
-	public ChoiceParameter(String prompt, S defaultValue, S[] choices, String helpText) {
-		this(prompt, defaultValue, Arrays.asList(choices), helpText);
+	public ChoiceParameter(String group, String prompt, S defaultValue, S[] choices, String helpText) {
+		this(group, prompt, defaultValue, Arrays.asList(choices), helpText);
 	}
 
 	public List<S> getChoices() {
@@ -64,10 +64,19 @@ public class ChoiceParameter<S> extends AbstractParameter<S> {
 	}
 
 	@Override
+	public S getStoredValue(){
+		S defaultValue = getDefaultValue();
+		if (defaultValue instanceof String)
+			return (S) prefs.get(getPrompt(), defaultValue.toString());
+		else
+			return getDefaultValue();
+	}
+
+	@Override
 	public boolean isValidInput(S value) {
 		return choices.contains(value);
 	}
-	
+
 	/**
 	 * This will only work for string choices... for other types it will always return false
 	 * and fail to set the lastValue
@@ -77,6 +86,7 @@ public class ChoiceParameter<S> extends AbstractParameter<S> {
 		for (S choice : choices) {
 			String choiceValue = choice.toString();
 			if (choiceValue.equals(value)) {
+				prefs.put(getPrompt(), choiceValue);
 				return setValue(choice);
 			}
 		}
@@ -92,7 +102,7 @@ public class ChoiceParameter<S> extends AbstractParameter<S> {
 
 	@Override
 	public Parameter<S> duplicate() {
-		return new ChoiceParameter<>(getPrompt(), getDefaultValue(), getChoices(), getValue(), getHelpText(), isHidden());
+		return new ChoiceParameter<>(getGroup(), getPrompt(), getDefaultValue(), getChoices(), getValue(), getHelpText(), isHidden());
 	}
 
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/DoubleParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/DoubleParameter.java
@@ -35,16 +35,16 @@ public class DoubleParameter extends NumericParameter<Double> {
 	
 	private static final long serialVersionUID = 1L;
 
-	DoubleParameter(String prompt, Double defaultValue, String unit, Double minValue, Double maxValue, Double lastValue, String helpText, boolean isHidden) {
-		super(prompt, defaultValue, unit, minValue, maxValue, lastValue, helpText, isHidden);
+	DoubleParameter(String group, String prompt, Double defaultValue, String unit, Double minValue, Double maxValue, Double lastValue, String helpText, boolean isHidden) {
+		super(group, prompt, defaultValue, unit, minValue, maxValue, lastValue, helpText, isHidden);
 	}
 
-	public DoubleParameter(String prompt, Double defaultValue, String unit, Double minValue, Double maxValue, String helpText) {
-		super(prompt, defaultValue, unit, minValue, maxValue, helpText);
+	public DoubleParameter(String group, String prompt, Double defaultValue, String unit, Double minValue, Double maxValue, String helpText) {
+		super(group, prompt, defaultValue, unit, minValue, maxValue, helpText);
 	}
 
-	public DoubleParameter(String prompt, Double defaultValue, String unit, String helpText) {
-		super(prompt, defaultValue, unit, helpText);
+	public DoubleParameter(String group, String prompt, Double defaultValue, String unit, String helpText) {
+		super(group, prompt, defaultValue, unit, helpText);
 	}
 	
 	/**
@@ -57,14 +57,21 @@ public class DoubleParameter extends NumericParameter<Double> {
 		if (!isValidInput(lastValue))
 			return false;
 		this.lastValue = lastValue;
+		prefs.putDouble(getPrompt(), lastValue);
 //		this.lastValue = Math.max(Math.min(lastValue, getUpperBound()), getLowerBound());
 		return true;
 	}
-	
+
+	@Override
+	public Double getStoredValue() {
+		return prefs.getDouble(getPrompt(), getDefaultValue());
+	}
+
 	@Override
 	public boolean setValueWithBoundsCheck(Double lastValue) {
 		if (!isValidInput(lastValue))
 			return false;
+		prefs.putDouble(getPrompt(), lastValue);
 		this.lastValue = Math.max(Math.min(lastValue, getUpperBound()), getLowerBound());
 		return true;
 	}
@@ -76,7 +83,7 @@ public class DoubleParameter extends NumericParameter<Double> {
 
 	@Override
 	public Parameter<Double> duplicate() {
-		return new DoubleParameter(getPrompt(), getDefaultValue(), getUnit(), getLowerBound(), getUpperBound(), getValue(), getHelpText(), isHidden());
+		return new DoubleParameter(getGroup(), getPrompt(), getDefaultValue(), getUnit(), getLowerBound(), getUpperBound(), getValue(), getHelpText(), isHidden());
 	}
 	
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/EmptyParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/EmptyParameter.java
@@ -38,8 +38,8 @@ public class EmptyParameter extends AbstractParameter<String> {
 
 	protected boolean isTitle = false;
 	
-	EmptyParameter(String prompt, boolean isTitle, boolean isHidden) {
-		super(prompt, null, null, null, isHidden);
+	EmptyParameter(String group, String prompt, boolean isTitle, boolean isHidden) {
+		super(group, prompt, null, null, null, isHidden);
 		this.isTitle = isTitle;
 	}
 	
@@ -53,12 +53,12 @@ public class EmptyParameter extends AbstractParameter<String> {
 	 * @param prompt
 	 * @param defaultValue
 	 */
-	public EmptyParameter(String prompt, boolean isTitle) {
-		this(prompt, isTitle, false);
+	public EmptyParameter(String group, String prompt, boolean isTitle) {
+		this(group, prompt, isTitle, false);
 	}
 	
-	public EmptyParameter(String prompt) {
-		this(prompt, false);
+	public EmptyParameter(String group, String prompt) {
+		this(group, prompt, false);
 	}
 	
 	public boolean isTitle() {
@@ -85,7 +85,7 @@ public class EmptyParameter extends AbstractParameter<String> {
 
 	@Override
 	public Parameter<String> duplicate() {
-		return new EmptyParameter(getPrompt(), isTitle);
+		return new EmptyParameter(getGroup(), getPrompt(), isTitle);
 	}
 
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ImmutableParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ImmutableParameter.java
@@ -53,6 +53,11 @@ public class ImmutableParameter<S> implements Parameter<S> {
 	}
 
 	@Override
+	public void setDefaultValue(S value) {
+		throw new UnsupportedOperationException(this + " is immutable - value cannot be set");
+	}
+
+	@Override
 	public boolean setStringLastValue(Locale locale, String value) {
 		throw new UnsupportedOperationException(this + " is immutable - value cannot be set");
 	}
@@ -76,6 +81,9 @@ public class ImmutableParameter<S> implements Parameter<S> {
 	public String getPrompt() {
 		return parameter.getPrompt();
 	}
+
+	@Override
+	public String getGroup() { return parameter.getGroup(); }
 
 	@Override
 	public boolean isValidInput(S value) {

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/IntParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/IntParameter.java
@@ -35,16 +35,16 @@ public class IntParameter extends NumericParameter<Integer> {
 	
 	private static final long serialVersionUID = 1L;
 	
-	IntParameter(String prompt, Integer defaultValue, String unit, Double minValue, Double maxValue, Integer lastValue, String helpText, boolean isHidden) {
-		super(prompt, defaultValue, unit, minValue, maxValue, lastValue, helpText, isHidden);
+	IntParameter(String group, String prompt, Integer defaultValue, String unit, Double minValue, Double maxValue, Integer lastValue, String helpText, boolean isHidden) {
+		super(group, prompt, defaultValue, unit, minValue, maxValue, lastValue, helpText, isHidden);
 	}
 	
-	public IntParameter(String prompt, Integer defaultValue, String unit, Double minValue, Double maxValue, String helpText) {
-		this(prompt, defaultValue, unit, minValue, maxValue, null, helpText, false);
+	public IntParameter(String group, String prompt, Integer defaultValue, String unit, Double minValue, Double maxValue, String helpText) {
+		this(group, prompt, defaultValue, unit, minValue, maxValue, null, helpText, false);
 	}
 
-	public IntParameter(String prompt, Integer defaultValue, String unit, String helpText) {
-		super(prompt, defaultValue, unit, helpText);
+	public IntParameter(String group, String prompt, Integer defaultValue, String unit, String helpText) {
+		super(group, prompt, defaultValue, unit, helpText);
 	}
 
 	/**
@@ -56,14 +56,21 @@ public class IntParameter extends NumericParameter<Integer> {
 	public boolean setValue(Integer lastValue) {
 		if (!isValidInput(lastValue))
 			return false;
+		prefs.putInt(getPrompt(), lastValue);
 		this.lastValue = lastValue;
 		return true;
+	}
+
+	@Override
+	protected Integer getStoredValue() {
+		return prefs.getInt(getPrompt(), getDefaultValue());
 	}
 	
 	@Override
 	public boolean setValueWithBoundsCheck(Integer lastValue) {
 		if (!isValidInput(lastValue))
 			return false;
+		prefs.putInt(getPrompt(), lastValue);
 		this.lastValue = (int)Math.max(Math.min(lastValue, getUpperBound()), getLowerBound());
 		return true;
 	}
@@ -75,7 +82,7 @@ public class IntParameter extends NumericParameter<Integer> {
 
 	@Override
 	public Parameter<Integer> duplicate() {
-		return new IntParameter(getPrompt(), getDefaultValue(), getUnit(), getLowerBound(), getUpperBound(), lastValue, getHelpText(), isHidden());
+		return new IntParameter(getGroup(), getPrompt(), getDefaultValue(), getUnit(), getLowerBound(), getUpperBound(), lastValue, getHelpText(), isHidden());
 	}
 
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/NumericParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/NumericParameter.java
@@ -44,19 +44,19 @@ public abstract class NumericParameter<S extends Number> extends AbstractParamet
 	private double minValue = Double.NEGATIVE_INFINITY;
 	private double maxValue = Double.POSITIVE_INFINITY;
 	
-	NumericParameter(String prompt, S defaultValue, String unit, double minValue, double maxValue, S lastValue, String helpText, boolean isHidden) {
-		super(prompt, defaultValue, lastValue, helpText, isHidden);
+	NumericParameter(String group, String prompt, S defaultValue, String unit, double minValue, double maxValue, S lastValue, String helpText, boolean isHidden) {
+		super(group, prompt, defaultValue, lastValue, helpText, isHidden);
 		this.unit = unit;
 		this.minValue = minValue;
 		this.maxValue = maxValue;
 	}
 	
-	public NumericParameter(String prompt, S defaultValue, String unit, double minValue, double maxValue, String helpText) {
-		this(prompt, defaultValue, unit, minValue, maxValue, null, helpText, false);
+	public NumericParameter(String group, String prompt, S defaultValue, String unit, double minValue, double maxValue, String helpText) {
+		this(group, prompt, defaultValue, unit, minValue, maxValue, null, helpText, false);
 	}
 
-	public NumericParameter(String prompt, S defaultValue, String unit, String helpText) {
-		this(prompt, defaultValue, unit, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, helpText);
+	public NumericParameter(String group, String prompt, S defaultValue, String unit, String helpText) {
+		this(group, prompt, defaultValue, unit, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, helpText);
 	}
 	
 	public boolean hasLowerAndUpperBounds() {

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/Parameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/Parameter.java
@@ -42,6 +42,14 @@ public interface Parameter<S> extends Serializable {
 	public S getDefaultValue();
 
 	/**
+	 * Set the Parameter to have a specified default value.
+	 * @param value
+	 * @return
+	 */
+	public void setDefaultValue(S value);
+
+
+	/**
 	 * Set the Parameter to have a specified value.
 	 * @param value
 	 * @return
@@ -81,7 +89,13 @@ public interface Parameter<S> extends Serializable {
 	 * @return
 	 */
 	public String getPrompt();
-	
+
+	/**
+	 * Get group name for preference storage
+	 * @return
+	 */
+	public String getGroup();
+
 	public boolean isValidInput(S value);
 	
 	/**

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ParameterList.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ParameterList.java
@@ -47,17 +47,21 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class ParameterList implements Serializable {
-	
+
 	private static final long serialVersionUID = 1L;
 	
 	private final static Logger logger = LoggerFactory.getLogger(ParameterList.class);
 	
 	private Map<String, Parameter<?>> params = new LinkedHashMap<>();
-	
-//	public ParameterList() {};
-	
+
+	private String group;
+
+	public ParameterList(String group) {
+		this.group = group;
+	};
+
 	public static ParameterList copyParameters(ParameterList params) {
-		ParameterList paramsCopy = new ParameterList();
+		ParameterList paramsCopy = new ParameterList(params.getGroup());
 		for (Entry<String, Parameter<?>> entry : params.params.entrySet()) {
 			paramsCopy.params.put(entry.getKey(), entry.getValue().duplicate());
 		}
@@ -101,12 +105,12 @@ public class ParameterList implements Serializable {
 	}
 	
 	public ParameterList addDoubleParameter(String key, String prompt, double defaultValue, String unit, String helpText) {
-		params.put(key, new DoubleParameter(prompt, defaultValue, unit, helpText));
+		params.put(key, new DoubleParameter(group, prompt, defaultValue, unit, helpText));
 		return this;
 	}
 	
 	public ParameterList addDoubleParameter(String key, String prompt, double defaultValue, String unit, double lowerBound, double upperBound, String helpText) {
-		params.put(key, new DoubleParameter(prompt, defaultValue, unit, lowerBound, upperBound, helpText));
+		params.put(key, new DoubleParameter(group, prompt, defaultValue, unit, lowerBound, upperBound, helpText));
 		return this;
 	}
 	
@@ -130,22 +134,22 @@ public class ParameterList implements Serializable {
 
 
 	public ParameterList addIntParameter(String key, String prompt, int defaultValue, String unit, String helpText) {
-		params.put(key, new IntParameter(prompt, defaultValue, unit, helpText));
+		params.put(key, new IntParameter(group, prompt, defaultValue, unit, helpText));
 		return this;
 	}
 
 	public ParameterList addIntParameter(String key, String prompt, int defaultValue, String unit, double lowerBound, double upperBound, String helpText) {
-		params.put(key, new IntParameter(prompt, defaultValue, unit, lowerBound, upperBound, helpText));
+		params.put(key, new IntParameter(group, prompt, defaultValue, unit, lowerBound, upperBound, helpText));
 		return this;
 	}
 	
 	public ParameterList addEmptyParameter(String key, String prompt) {
-		params.put(key, new EmptyParameter(prompt));
+		params.put(key, new EmptyParameter(group, prompt));
 		return this;
 	}
 	
 	public ParameterList addEmptyParameter(String key, String prompt, boolean isTitle) {
-		params.put(key, new EmptyParameter(prompt, isTitle));
+		params.put(key, new EmptyParameter(group, prompt, isTitle));
 		return this;
 	}
 	
@@ -168,7 +172,7 @@ public class ParameterList implements Serializable {
 	}
 
 	public ParameterList addBooleanParameter(String key, String prompt, boolean defaultValue, String helpText) {
-		params.put(key, new BooleanParameter(prompt, defaultValue, helpText));
+		params.put(key, new BooleanParameter(group, prompt, defaultValue, helpText));
 		return this;
 	}
 
@@ -177,7 +181,7 @@ public class ParameterList implements Serializable {
 	}
 	
 	public ParameterList addStringParameter(String key, String prompt, String defaultValue, String helpText) {
-		params.put(key, new StringParameter(prompt, defaultValue, helpText));
+		params.put(key, new StringParameter(group, prompt, defaultValue, helpText));
 		return this;
 	}
 	
@@ -190,12 +194,12 @@ public class ParameterList implements Serializable {
 	}
 	
 	public <S> ParameterList addChoiceParameter(String key, String prompt, S defaultValue, S[] choices, String helpText) {
-		params.put(key, new ChoiceParameter<S>(prompt, defaultValue, choices, helpText));
+		params.put(key, new ChoiceParameter<S>(group, prompt, defaultValue, choices, helpText));
 		return this;
 	}
 
 	public <S> ParameterList addChoiceParameter(String key, String prompt, S defaultValue, List<S> choices, String helpText) {
-		params.put(key, new ChoiceParameter<S>(prompt, defaultValue, choices, helpText));
+		params.put(key, new ChoiceParameter<S>(group, prompt, defaultValue, choices, helpText));
 		return this;
 	}
 
@@ -375,8 +379,9 @@ public class ParameterList implements Serializable {
 	//					params.addBooleanParameter(InteractivePluginTools.KEY_SKIP_NON_EMPTY, "Skip non-empty", Boolean.parseBoolean(entry.getValue()));
 	//				else
 						logger.warn("Unable to set parameter {} with value {}", key, entry.getValue());
-				} else
+				} else {
 					parameter.setStringLastValue(locale, entry.getValue());
+				}
 			}
 		}
 
@@ -485,6 +490,7 @@ public class ParameterList implements Serializable {
 //	public Parameter<? extends Object> putParameter(String key, Parameter<?> parameter) {
 //		return params.put(key, parameter);
 //	}
-	
+
+	public String getGroup() { return group; }
 
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/StringParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/StringParameter.java
@@ -35,12 +35,17 @@ public class StringParameter extends AbstractParameter<String> {
 	
 	private static final long serialVersionUID = 1L;
 
-	StringParameter(String prompt, String defaultValue, String lastValue, String helpText, boolean isHidden) {
-		super(prompt, defaultValue, lastValue, helpText, isHidden);
+	StringParameter(String group, String prompt, String defaultValue, String lastValue, String helpText, boolean isHidden) {
+		super(group, prompt, defaultValue, lastValue, helpText, isHidden);
 	}
 
-	public StringParameter(String prompt, String defaultValue, String helpText) {
-		this(prompt, defaultValue, null, helpText, false);
+	public StringParameter(String group, String prompt, String defaultValue, String helpText) {
+		this(group, prompt, defaultValue, null, helpText, false);
+	}
+
+	@Override
+	protected String getStoredValue() {
+		return prefs.get(getPrompt(), getDefaultValue());
 	}
 
 	@Override
@@ -50,12 +55,13 @@ public class StringParameter extends AbstractParameter<String> {
 
 	@Override
 	public boolean setStringLastValue(Locale locale, String value) {
+		prefs.put(getPrompt(), value);
 		return setValue(value);
 	}
 
 	@Override
 	public Parameter<String> duplicate() {
-		return new StringParameter(getPrompt(), getDefaultValue(), getValue(), getHelpText(), isHidden());
+		return new StringParameter(getGroup(), getPrompt(), getDefaultValue(), getValue(), getHelpText(), isHidden());
 	}
 
 }

--- a/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ThresholdParameter.java
+++ b/qupath-core-processing/src/main/java/qupath/lib/plugins/parameters/ThresholdParameter.java
@@ -40,17 +40,17 @@ class ThresholdParameter extends DoubleParameter {
 	
 	private Histogram histogram;
 
-	ThresholdParameter(String prompt, Double defaultValue, Histogram histogram, String unit, Double minValue, Double maxValue, Double lastValue, String helpText, boolean isHidden) {
-		super(prompt, defaultValue, unit, minValue, maxValue, lastValue, helpText, isHidden);
+	ThresholdParameter(String group, String prompt, Double defaultValue, Histogram histogram, String unit, Double minValue, Double maxValue, Double lastValue, String helpText, boolean isHidden) {
+		super(group, prompt, defaultValue, unit, minValue, maxValue, lastValue, helpText, isHidden);
 		this.histogram = histogram;
 	}
 
-	public ThresholdParameter(String prompt, Histogram histogram, Double defaultValue, String unit, double minValue, double maxValue, String helpText) {
-		super(prompt, defaultValue, unit, minValue, maxValue, helpText);
+	public ThresholdParameter(String group, String prompt, Histogram histogram, Double defaultValue, String unit, double minValue, double maxValue, String helpText) {
+		super(group, prompt, defaultValue, unit, minValue, maxValue, helpText);
 	}
 
-	public ThresholdParameter(String prompt, Histogram histogram, Double defaultValue, String unit, String helpText) {
-		this(prompt, histogram, defaultValue, unit, histogram.getMinValue(), histogram.getMaxValue(), helpText);
+	public ThresholdParameter(String group, String prompt, Histogram histogram, Double defaultValue, String unit, String helpText) {
+		this(group, prompt, histogram, defaultValue, unit, histogram.getMinValue(), histogram.getMaxValue(), helpText);
 	}
 	
 	/**
@@ -77,7 +77,7 @@ class ThresholdParameter extends DoubleParameter {
 
 	@Override
 	public Parameter<Double> duplicate() {
-		return new ThresholdParameter(getPrompt(), getDefaultValue(), getHistogram(), getUnit(), getLowerBound(), getUpperBound(), getValue(), getHelpText(), isHidden());
+		return new ThresholdParameter(getGroup(), getPrompt(), getDefaultValue(), getHistogram(), getUnit(), getLowerBound(), getUpperBound(), getValue(), getHelpText(), isHidden());
 	}
 	
 }

--- a/qupath-extension-ij/src/main/java/qupath/imagej/plugins/ImageJMacroRunner.java
+++ b/qupath-extension-ij/src/main/java/qupath/imagej/plugins/ImageJMacroRunner.java
@@ -363,7 +363,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 
 	public ParameterList getParameterList(final ImageData<BufferedImage> imageData) {
 		if (params == null)
-			params = new ParameterList()
+			params = new ParameterList(getName())
 				.addTitleParameter("Setup")
 				.addDoubleParameter("downsampleFactor", "Downsample factor", 1)
 				//			.addBooleanParameter("useTransform", "Send color transformed image", true) // Not supported in batch mode, so disable option to avoid confusion

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -1308,7 +1308,7 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 		long maxMemoryMB = Runtime.getRuntime().maxMemory() / 1024 / 1024;
 		String maxMemoryString = String.format("Current maximum memory is %.2f GB.", maxMemoryMB/1024.0);
 		
-		ParameterList paramsSetup = new ParameterList()
+		ParameterList paramsSetup = new ParameterList("Memory")
 				.addTitleParameter("Memory")
 				.addEmptyParameter("memoryString", "Set the maximum memory used by QuPath, or -1 to use the default.")
 				.addEmptyParameter("memoryString2", maxMemoryString);
@@ -3935,7 +3935,7 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 						return;
 					double fullMagnification = viewer.getServer().getMagnification();
 					boolean hasMagnification = !Double.isNaN(fullMagnification);
-					ParameterList params = new ParameterList();
+					ParameterList params = new ParameterList("Magnification");
 					if (hasMagnification) {
 						double defaultValue = Math.rint(viewer.getMagnification() * 1000) / 1000;
 						params.addDoubleParameter("magnification", "Enter magnification", defaultValue);
@@ -3983,7 +3983,7 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 				if (e.isPopupTrigger() || e.getClickCount() < 2)
 					return;
 
-				final ParameterList params = new ParameterList()
+				final ParameterList params = new ParameterList("Brush")
 						.addDoubleParameter("brushSize", "Brush diameter", PathPrefs.getBrushDiameter(), "pixels")
 						.addBooleanParameter("brushScaleMag", "Scale brush size by magnification", PathPrefs.getBrushScaleByMag())
 						.addBooleanParameter("brushCreateNew", "Create new objects when painting", PathPrefs.getBrushCreateNewObjects());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/EstimateStainVectorsCommand.java
@@ -262,7 +262,7 @@ public class EstimateStainVectorsCommand implements PathCommand {
 		
 		
 		// Create auto detection parameters
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList("EstimateStainVectorsCommand")
 				.addDoubleParameter("minStainOD", "Min channel OD", 0.05, "", "Minimum staining OD - pixels with a lower OD in any channel (RGB) are ignored (default = 0.05)")
 				.addDoubleParameter("maxStainOD", "Max total OD", 1., "", "Maximum staining OD - more densely stained pixels are ignored (default = 1)")
 				.addDoubleParameter("ignorePercentage", "Ignore extrema", 1., "%", "Percentage of extreme pixels to ignore, to improve robustness in the presence of noise/other artefacts (default = 1)")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SetGridSpacingCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/SetGridSpacingCommand.java
@@ -48,7 +48,7 @@ public class SetGridSpacingCommand implements PathCommand {
 	public void run() {
 		GridLines gridLines = overlayOptions.getGridLines();
 		
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList("SetGridSpacingCommand")
 				.addDoubleParameter("hSpacing", "Horizontal spacing", gridLines.getSpaceX())
 				.addDoubleParameter("vSpacing", "Vertical spacing", gridLines.getSpaceX())
 				.addBooleanParameter("useMicrons", "Use microns", gridLines.useMicrons());

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/scriptable/SelectObjectsByMeasurementCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/scriptable/SelectObjectsByMeasurementCommand.java
@@ -71,7 +71,7 @@ public class SelectObjectsByMeasurementCommand implements PathCommand {
 	private int lastCaretPos = 0;
 	
 	private ObservableList<String> features = FXCollections.observableArrayList();
-//	private ParameterList params = new ParameterList().addStringParameter("keyPredicate", "Predicate", "");
+//	private ParameterList params = new ParameterList(getName()).addStringParameter("keyPredicate", "Predicate", "");
 	
 	
 	public SelectObjectsByMeasurementCommand(final QuPathGUI qupath) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/scriptable/TMAGridRelabel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/scriptable/TMAGridRelabel.java
@@ -68,7 +68,7 @@ public class TMAGridRelabel implements PathCommand {
 			return;
 		}
 		
-		ParameterList params = new ParameterList();
+		ParameterList params = new ParameterList("TMAGridRelabel");
 		params.addStringParameter("labelsHorizontal", "Column labels", columnLabelsProperty.get(), "Enter column labels.\nThis can be a continuous range of letters or numbers (e.g. 1-10 or A-J),\nor a discontinuous list separated by spaces (e.g. A B C E F G).");
 		params.addStringParameter("labelsVertical", "Row labels", rowLabelsProperty.get(), "Enter row labels.\nThis can be a continuous range of letters or numbers (e.g. 1-10 or A-J),\nor a discontinuous list separated by spaces (e.g. A B C E F G).");
 		params.addChoiceParameter("labelOrder", "Label order", rowFirstProperty.get() ? "Row first" : "Column first", new String[]{"Column first", "Row first"}, "Create TMA labels either in the form Row-Column or Column-Row");

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/helpers/AnnotationCreatorPanel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/helpers/AnnotationCreatorPanel.java
@@ -52,7 +52,7 @@ public class AnnotationCreatorPanel {
 	
 	private ColorPicker colorPicker = new ColorPicker(ColorToolsFX.getCachedColor(PathPrefs.getColorDefaultAnnotations()));
 	
-	private ParameterList params = new ParameterList()
+	private ParameterList params = new ParameterList("AnnotationCreatorPanel")
 //			.addEmptyParameter("t1", "Properties")
 			.addChoiceParameter("type", "Type", "Rectangle", new String[]{"Rectangle", "Ellipse"})
 			.addStringParameter("name", "Name", "")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/helpers/dialogs/ParameterPanelFX.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/helpers/dialogs/ParameterPanelFX.java
@@ -611,7 +611,7 @@ public class ParameterPanelFX {
 		Stage frame = new Stage();
 		frame.setTitle("Testing parameter panel");
 		int k = 0;
-		final ParameterList params = new ParameterList().
+		final ParameterList params = new ParameterList("Testing").
 				addEmptyParameter(Integer.toString(k++), "Parameter list", true).
 				addEmptyParameter(Integer.toString(k++), "Here is a list of parameters that I am testing out", false).
 				addIntParameter(Integer.toString(k++), "Enter an int", 5, "px").

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/legacy/swing/ParameterPanel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/legacy/swing/ParameterPanel.java
@@ -590,7 +590,7 @@ public class ParameterPanel extends JPanel implements Scrollable {
 	public static void main(String[] args) {
 		JFrame frame = new JFrame("Testing parameter panel");
 		int k = 0;
-		final ParameterList params = new ParameterList().
+		final ParameterList params = new ParameterList("TestingParameterPanel").
 				addEmptyParameter(Integer.toString(k++), "Parameter list", true).
 				addEmptyParameter(Integer.toString(k++), "Here is a list of parameters that I am testing out", false).
 				addIntParameter(Integer.toString(k++), "Enter an int", 5, "px").

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/models/HistogramDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/models/HistogramDisplay.java
@@ -78,7 +78,7 @@ public class HistogramDisplay implements ParameterChangeListener {
 	private double[] currentValues;
 	private String currentColumn = null;
 
-	private ParameterList params = new ParameterList()
+	private ParameterList params = new ParameterList("HistogramDisplay")
 			.addBooleanParameter("normalizeCounts", "Normalize counts", false, "Normalize counts (probability distribution)")
 			.addBooleanParameter("drawGrid", "Draw grid", true, "Draw grid")
 			.addBooleanParameter("drawAxes", "Draw axes", true, "Draw axes")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/PathImageDetailsPanel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/PathImageDetailsPanel.java
@@ -362,7 +362,7 @@ public class PathImageDetailsPanel implements ImageDataChangeListener<BufferedIm
 		}
 
 		// Prompt to set the name / verify stains
-		ParameterList params = new ParameterList();
+		ParameterList params = new ParameterList("PathImageDetailsPanel");
 		String title;
 		String nameBefore = null;
 		String valuesBefore = null;

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/ClassifierBuilderPanel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/ClassifierBuilderPanel.java
@@ -180,7 +180,7 @@ public class ClassifierBuilderPanel<T extends PathObjectClassifier> implements P
 	//	private Map<String, Map<PathClass, List<PathObject>>> retainedObjectsMap = new HashMap<>();
 
 
-	private ParameterList paramsUpdate = new ParameterList()
+	private ParameterList paramsUpdate = new ParameterList("ClassifierBuilderPanel")
 			.addChoiceParameter("normalizationMethod", "Normalization method", Normalization.NONE, Normalization.values(), "Method to normalize features - some classifiers (e.g. SVM) require this, while others (e.g. decision trees, random forests) don't")
 			.addIntParameter("maxTrainingPercent", "Training set split", 100, "%", 1, 100, "Percentage of the data to use for training - the rest will be used for testing")
 			.addChoiceParameter("splitType", "Training set split type", SplitType.EQUIDISTANT, SplitType.values(), "Method of splitting the data for training")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/PathIntensityClassifierPanel.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/PathIntensityClassifierPanel.java
@@ -205,7 +205,7 @@ public class PathIntensityClassifierPanel implements PathObjectSelectionListener
 		double threshold_1 = 0.2;
 		double threshold_2 = 0.4;
 		double threshold_3 = 0.6;
-		paramsIntensity = new ParameterList()
+		paramsIntensity = new ParameterList("PathIntensityClassifierPanel")
 				.addDoubleParameter("threshold_1", "Threshold 1+", threshold_1, null, 0, 1.5, "Set first intensity threshold, if required (lowest)")
 				.addDoubleParameter("threshold_2", "Threshold 2+", threshold_2, null, 0, 1.5, "Set second intensity threshold, if required (intermediate)")
 				.addDoubleParameter("threshold_3", "Threshold 3+", threshold_3, null, 0, 1.5, "Set third intensity threshold, if required (highest)")

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/RandomTrainingRegionSelector.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/classify/RandomTrainingRegionSelector.java
@@ -116,7 +116,7 @@ public class RandomTrainingRegionSelector implements PathCommand {
 	private Label labelCount;
 	private RandomPointCreator pointCreator;
 	
-	private ParameterList params = new ParameterList().addIntParameter("nClusters", "Number of clusters", 1, null, 1, 5, "Precluster the data to assist with coverage using random selection");
+	private ParameterList params = new ParameterList("RandomTrainingRegionSelector").addIntParameter("nClusters", "Number of clusters", 1, null, 1, 5, "Precluster the data to assist with coverage using random selection");
 	
 	
 	public RandomTrainingRegionSelector(final QuPathGUI qupath, final ObservableList<PathClass> pathClassListModel) {

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/survival/KaplanMeierDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/survival/KaplanMeierDisplay.java
@@ -692,7 +692,7 @@ public class KaplanMeierDisplay implements ParameterChangeListener, PathObjectHi
 			table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
 			table.maxHeightProperty().bind(table.prefHeightProperty());
 
-			params = new ParameterList();
+			params = new ParameterList("KaplanMeierDisplay");
 			//			maxTimePoint = 0;
 			//			for (TMACoreObject core : hierarchy.getTMAGrid().getTMACoreList()) {
 			//				double os = core.getMeasurementList().getMeasurementValue(TMACoreObject.KEY_OVERALL_SURVIVAL);

--- a/qupath-gui-fx/src/main/java/qupath/lib/plugins/ParameterDialogWrapper.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/plugins/ParameterDialogWrapper.java
@@ -306,7 +306,7 @@ public class ParameterDialogWrapper<T> {
 		}
 
 		// Prepare to prompt
-		ParameterList paramsParents = new ParameterList();
+		ParameterList paramsParents = new ParameterList("ParameterDialogWrapper");
 		paramsParents.addChoiceParameter(KEY_REGIONS, "Process all", choiceList.get(0), choiceList);
 
 		if (!DisplayHelpers.showParameterDialog("Process regions", paramsParents))

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/cells/SubcellularDetection.java
@@ -397,7 +397,7 @@ public class SubcellularDetection extends AbstractInteractivePlugin<BufferedImag
 	@Override
 	public ParameterList getDefaultParameterList(final ImageData<BufferedImage> imageData) {
 		
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList(getName())
 				.addTitleParameter("Detection parameters");
 		
 		for (String name : new ImageWrapper(imageData, regionStore).getChannelNames(true, true)) {

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/dearray/TMADearrayerPluginIJ.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/dearray/TMADearrayerPluginIJ.java
@@ -77,7 +77,7 @@ public class TMADearrayerPluginIJ extends AbstractInteractivePlugin<BufferedImag
 	public TMADearrayerPluginIJ() {
 		
 		// Create default parameter list
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		params.addDoubleParameter("coreDiameterMM", "TMA core diameter", 1.2, "mm", "Enter the approximate diameter or each TMA core in mm");
 		params.addDoubleParameter("coreDiameterPixels", "TMA core diameter", 5000, "px", "Enter the approximate diameter or each TMA core in pixels");
 		

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/features/ImmuneScorerTMA.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/features/ImmuneScorerTMA.java
@@ -86,7 +86,7 @@ public class ImmuneScorerTMA extends AbstractInteractivePlugin<BufferedImage> {
 	
 	
 	public ImmuneScorerTMA() {
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		params.addDoubleParameter("tumourHoleDiameterMicrons", "Maximum tumour space diameter", 25, GeneralTools.micrometerSymbol(), 
 				"Choose the maximum diameter of a gap within a tumour region that should be filled when identifying infiltrating cells");
 		params.addDoubleParameter("tumourHoleDiameterPixels", "Maximum tumour space diameter", 25, "pixels", 

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellDetection.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellDetection.java
@@ -142,7 +142,7 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 	
 	
 	public WatershedCellDetection() {
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		// TODO: Use a better way to determining if pixel size is available in microns
 //		params.addEmptyParameter("detectionParameters", "Detection parameters", true);
 
@@ -421,9 +421,9 @@ public class WatershedCellDetection extends AbstractTileableDetectionPlugin<Buff
 		
 		if (!isBrightfield) {
 			if (imageData.getServer().getBitsPerPixel() > 8)
-				((DoubleParameter)params.getParameters().get("threshold")).setValue(100.0);
+				((DoubleParameter)params.getParameters().get("threshold")).setDefaultValue(100.0);
 			else
-				((DoubleParameter)params.getParameters().get("threshold")).setValue(25.0);
+				((DoubleParameter)params.getParameters().get("threshold")).setDefaultValue(25.0);
 		}
 
 //		map.get("detectionImageBrightfield").setHidden(imageData.getColorDeconvolutionStains() == null);

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellMembraneDetection.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellMembraneDetection.java
@@ -128,7 +128,7 @@ public class WatershedCellMembraneDetection extends AbstractTileableDetectionPlu
 	public WatershedCellMembraneDetection() {
 		
 		Prefs.setThreads(1);
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		// TODO: Use a better way to determining if pixel size is available in microns
 //		params.addEmptyParameter("detectionParameters", "Detection parameters", true);
 

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellMembraneDetectionWithBoundaries.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellMembraneDetectionWithBoundaries.java
@@ -122,7 +122,7 @@ public class WatershedCellMembraneDetectionWithBoundaries extends AbstractTileab
 	public WatershedCellMembraneDetectionWithBoundaries() {
 
 		Prefs.setThreads(1);
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		// TODO: Use a better way to determining if pixel size is available in microns
 		//		params.addEmptyParameter("detectionParameters", "Detection parameters", true);
 

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellMembraneDetectionWithBoundariesBackup.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedCellMembraneDetectionWithBoundariesBackup.java
@@ -118,7 +118,7 @@ public class WatershedCellMembraneDetectionWithBoundariesBackup extends Abstract
 	public WatershedCellMembraneDetectionWithBoundariesBackup() {
 
 		Prefs.setThreads(1);
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		// TODO: Use a better way to determining if pixel size is available in microns
 		//		params.addEmptyParameter("detectionParameters", "Detection parameters", true);
 

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedNucleusDetection.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/nuclei/WatershedNucleusDetection.java
@@ -94,7 +94,7 @@ public class WatershedNucleusDetection extends AbstractTileableDetectionPlugin<B
 	
 	
 	public WatershedNucleusDetection() {
-		params = new ParameterList();
+		params = new ParameterList(getName());
 		// TODO: Use a better way to determining if pixel size is available in microns
 		//		params.addEmptyParameter("detectionParameters", "Detection parameters", true);
 

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/tissue/PositivePixelCounterIJ.java
@@ -219,7 +219,7 @@ public class PositivePixelCounterIJ extends AbstractDetectionPlugin<BufferedImag
 
 	@Override
 	public ParameterList getDefaultParameterList(final ImageData<BufferedImage> imageData) {
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList(getName())
 				.addIntParameter("downsampleFactor", "Downsample factor", 4, "", 1, 32, "Amount to downsample image prior to detection - higher values lead to smaller images (and faster but less accurate processing)")
 				.addDoubleParameter("gaussianSigmaMicrons", "Gaussian sigma", 2, GeneralTools.micrometerSymbol(), "Gaussian filter size - higher values give a smoother (less-detailed) result")
 				.addDoubleParameter("thresholdStain1", "Hematoxylin threshold", 0.1, "OD units", "Threshold to use for hemtaoxylin detection")

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection.java
@@ -94,7 +94,7 @@ public class SimpleTissueDetection extends AbstractDetectionPlugin<BufferedImage
 	
 	
 	public SimpleTissueDetection() {
-		params = new ParameterList().
+		params = new ParameterList(getName()).
 				addIntParameter("threshold", "Threshold", 127, null, 0, 255);
 		
 		params.addDoubleParameter("minAreaMicrons", "Minimum area", 10000, GeneralTools.micrometerSymbol()+"^2");

--- a/qupath-processing-ij/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/detect/tissue/SimpleTissueDetection2.java
@@ -100,7 +100,7 @@ public class SimpleTissueDetection2 extends AbstractDetectionPlugin<BufferedImag
 	
 	public SimpleTissueDetection2(final ImageRegionStore<BufferedImage> regionStore) {
 		
-		params = new ParameterList().
+		params = new ParameterList(getName()).
 				addIntParameter("threshold", "Threshold", 127, null, 0, 255, "Global threshold to use - defined in the range 0-255");
 		
 		params.addDoubleParameter("requestedPixelSizeMicrons", "Requested pixel size", 20, GeneralTools.micrometerSymbol(), "Requested pixel size for detection resolution - higher values mean a less detailed (but faster) result.\nNote that if the resolution is set too high (leading to a huge image) it will be adjusted automatically.");

--- a/qupath-processing-ij/src/main/java/qupath/imagej/superpixels/DoGSuperpixelsPlugin.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/superpixels/DoGSuperpixelsPlugin.java
@@ -98,7 +98,7 @@ public class DoGSuperpixelsPlugin extends AbstractTileableDetectionPlugin<Buffer
 
 	@Override
 	public ParameterList getDefaultParameterList(ImageData<BufferedImage> imageData) {
-		ParameterList params = new ParameterList().
+		ParameterList params = new ParameterList(getName()).
 				addDoubleParameter("downsampleFactor", "Downsample factor", 8, null, "Downsample factor, used to determine the resolution of the image being processed").
 				addDoubleParameter("sigmaPixels", "Gaussian sigma", 10, "px", "Sigma value used for smoothing; higher values result in larger regions being created").
 				addDoubleParameter("sigmaMicrons", "Gaussian sigma", 10, GeneralTools.micrometerSymbol(), "Sigma value used for smoothing; higher values result in larger regions being created").

--- a/qupath-processing-ij/src/main/java/qupath/imagej/superpixels/GaussianSuperpixelsPlugin.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/superpixels/GaussianSuperpixelsPlugin.java
@@ -102,7 +102,7 @@ public class GaussianSuperpixelsPlugin extends AbstractTileableDetectionPlugin<B
 
 	@Override
 	public ParameterList getDefaultParameterList(ImageData<BufferedImage> imageData) {
-		ParameterList params = new ParameterList().
+		ParameterList params = new ParameterList(getName()).
 				addDoubleParameter("downsampleFactor", "Downsample factor", 8, null, "Downsample factor, used to determine the resolution of the image being processed").
 				addDoubleParameter("sigmaPixels", "Gaussian sigma", 10, "px", "Sigma value used for smoothing; higher values result in larger regions being created").
 				addDoubleParameter("sigmaMicrons", "Gaussian sigma", 10, GeneralTools.micrometerSymbol(), "Sigma value used for smoothing; higher values result in larger regions being created").

--- a/qupath-processing-ij/src/main/java/qupath/imagej/superpixels/SLICSuperpixelsPlugin.java
+++ b/qupath-processing-ij/src/main/java/qupath/imagej/superpixels/SLICSuperpixelsPlugin.java
@@ -127,7 +127,7 @@ public class SLICSuperpixelsPlugin extends AbstractTileableDetectionPlugin<Buffe
 
 	@Override
 	public ParameterList getDefaultParameterList(ImageData<BufferedImage> imageData) {
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList(getName())
 				.addTitleParameter("Size parameters")
 				.addDoubleParameter("sigmaPixels", "Gaussian sigma", 5, "px", "Adjust the Gaussian smoothing applied to the image, to reduce textures and give a smoother result")
 				.addDoubleParameter("sigmaMicrons", "Gaussian sigma", 5, GeneralTools.micrometerSymbol(), "Adjust the Gaussian smoothing applied to the image, to reduce textures and give a smoother result")

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/CellCountsCV.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/CellCountsCV.java
@@ -360,7 +360,7 @@ public class CellCountsCV extends AbstractTileableDetectionPlugin<BufferedImage>
 	
 	@Override
 	public ParameterList getDefaultParameterList(final ImageData<BufferedImage> imageData) {
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList(getName())
 				.addTitleParameter("Detection image")
 				.addChoiceParameter("stainChannel", "Cell detection channel", HEMATOXYLIN, STAIN_CHANNELS, "Choose channel that will be thresholded to detect the cells")
 				// Magnification is deprecated!  Will be hidden, and only kept here for some backwards compatibility

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/DetectCytokeratinCV.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/DetectCytokeratinCV.java
@@ -304,7 +304,7 @@ public class DetectCytokeratinCV extends AbstractDetectionPlugin<BufferedImage> 
 
 	@Override
 	public ParameterList getDefaultParameterList(final ImageData<BufferedImage> imageData) {
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList(getName())
 				.addIntParameter("downsampleFactor", "Downsample factor", 4, "", 1, 32, "Amount to downsample image prior to detection - higher values lead to smaller images (and faster but less accurate processing)")
 				.addDoubleParameter("gaussianSigmaMicrons", "Gaussian sigma", 5, GeneralTools.micrometerSymbol(), "Gaussian filter size - higher values give a smoother (less-detailed) result")
 				.addDoubleParameter("thresholdTissue", "Tissue threshold", 0.1, "OD units", "Threshold to use for tissue detection (used to create stroma annotation) - if zero, no stroma annotation is created")

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/WatershedNucleiCV.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/WatershedNucleiCV.java
@@ -334,7 +334,7 @@ public class WatershedNucleiCV extends AbstractTileableDetectionPlugin<BufferedI
 
 	@Override
 	public ParameterList getDefaultParameterList(final ImageData<BufferedImage> imageData) {
-		ParameterList params = new ParameterList();
+		ParameterList params = new ParameterList(getName());
 		params.addDoubleParameter("preferredMicrons", "Preferred pixel size", 0.5, GeneralTools.micrometerSymbol());
 //				addIntParameter("downsampleFactor", "Downsample factor", 2, "", 1, 4);
 		

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/classify/BoostClassifier.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/classify/BoostClassifier.java
@@ -84,7 +84,7 @@ public class BoostClassifier extends ParameterizableOpenCvClassifier<Boost> {
 
 	@Override
 	protected ParameterList createParameterList() {
-		return new ParameterList()
+		return new ParameterList(getName())
 				.addChoiceParameter("boostType", "Boost type", "Real", new String[]{"Discrete", "Real", "Logit", "Gentle"})
 				.addIntParameter("weakCount", "Number of weak classifiers", 100, null, 1, 1000, "Number of weak classifiers")
 				.addIntParameter("maxDepth", "Max tree depth", 1, null, 1, 5, "Maximum tree depth (default = 1)");

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/classify/KNearestClassifier.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/classify/KNearestClassifier.java
@@ -60,7 +60,7 @@ public class KNearestClassifier extends ParameterizableOpenCvClassifier<KNearest
 
 	@Override
 	protected ParameterList createParameterList() {
-		return new ParameterList().addIntParameter("k", "K neighbors", 10, null, "Number of nearest neighbors to use");
+		return new ParameterList(getName()).addIntParameter("k", "K neighbors", 10, null, "Number of nearest neighbors to use");
 	}
 
 }

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/classify/NeuralNetworksClassifier.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/classify/NeuralNetworksClassifier.java
@@ -105,7 +105,7 @@ public class NeuralNetworksClassifier extends ParameterizableOpenCvClassifier<AN
 
 	@Override
 	protected ParameterList createParameterList() {
-		ParameterList params = new ParameterList();
+		ParameterList params = new ParameterList(getName());
 		params.addIntParameter("nHidden", "Number of hidden layers", 8, null, "Number of hidden layers for neural network (must be >= 2)");
 		
 		params.addIntParameter("termCritMaxIterations", "Termination criterion - max iterations", 100, null, "Optional termination criterion based on maximum number of iterations - set <= 0 to disable and use accuracy criterion only");

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/classify/RTreesClassifier.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/classify/RTreesClassifier.java
@@ -54,7 +54,7 @@ public class RTreesClassifier extends ParameterizableOpenCvClassifier<RTrees> im
 	
 	@Override
 	protected ParameterList createParameterList() {
-		ParameterList params = new ParameterList();
+		ParameterList params = new ParameterList(getName());
 		params.addIntParameter("maxDepth", "Max tree depth", 0, null, 0, 20, "Maximum tree depth; if zero, then the depth is effectively unlimited (set to max int)");
 		params.addIntParameter("minSamples", "Min samples per node", 10, null, "Minimum number of samples per node - the node will not be split if the number of samples is less than this (default = 10)");
 		params.addBooleanParameter("use1SE", "Prune aggressively", true, "If true, more aggressive pruning is used - likely sacrificing some accuracy for more robustness");

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/classify/SVMClassifier.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/classify/SVMClassifier.java
@@ -78,7 +78,7 @@ public class SVMClassifier extends ParameterizableOpenCvClassifier<SVM> {
 
 	@Override
 	protected ParameterList createParameterList() {
-		return new ParameterList()
+		return new ParameterList(getName())
 				.addChoiceParameter("kernel", "Kernel type", "RBF", new String[]{"Linear", "Polynomial", "RBF", "Histogram intersection"})
 				.addDoubleParameter("c", "C", 1, null, "C parameter for SVM optimization; must be > 0")
 				.addDoubleParameter("gamma", "Gamma", 1, null, "Gamma parameter for SVM optimization")

--- a/qupath-processing-opencv/src/main/java/qupath/opencv/features/DelaunayClusteringPlugin.java
+++ b/qupath-processing-opencv/src/main/java/qupath/opencv/features/DelaunayClusteringPlugin.java
@@ -103,7 +103,7 @@ public class DelaunayClusteringPlugin<T> extends AbstractInteractivePlugin<T> {
 
 	@Override
 	public ParameterList getDefaultParameterList(ImageData<T> imageData) {
-		ParameterList params = new ParameterList()
+		ParameterList params = new ParameterList(getName())
 				.addDoubleParameter("distanceThreshold", "Distance threshold", 0, "pixels", "Distance threshold - edges longer than this will be omitted")
 				.addDoubleParameter("distanceThresholdMicrons", "Distance threshold", 0, GeneralTools.micrometerSymbol(), "Distance threshold - edges longer than this will be omitted")
 				.addBooleanParameter("limitByClass", "Limit edges to same class", false, "Prevent edges linking objects with different base classifications")


### PR DESCRIPTION
Our group has recently come across QuPath and it seems to be very useful - thanks for sharing this tool!

One comment has been that user parameters are lost when a tool panel is closed. This can be a bit frustrating if you've spent a while optimising the parameters.  

This PR makes user-facing parameters persistent between instantiations of the panel (and indeed program) using the Java Preferences API. The default parameters are used in the first instance but are overridden once the user has established new parameters. I'm afraid it touches quite a few files but mostly trivially as the modified ParameterList needs to know where it is being called from. 