### PR TITLE
Incorporate fixes from other branches

### DIFF
--- a/qupath-core-processing-awt/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-core-processing-awt/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -481,10 +481,22 @@ public class ImageDisplay {
 	public String getTransformedValueAsString(BufferedImage img, int x, int y) {
 		if (selectedChannels == null || selectedChannels.isEmpty() || selectedChannels.get(0) == null)
 			return "";
-		String s = selectedChannels.get(0).getValueAsString(img, x, y);
-		for (int i = 1; i < selectedChannels.size(); i++) {
-			s += (", " + selectedChannels.get(i).getValueAsString(img, x, y));
+		if (selectedChannels.size() == 1)
+			return selectedChannels.get(0).getValueAsString(img, x, y);
+		
+		String s = null;
+		for (ChannelDisplayInfo channel : getAvailableChannels()) {
+			if (selectedChannels.contains(channel) ) {
+				if (s == null)
+					s = channel.getValueAsString(img, x, y);
+				else
+					s += (", " + channel.getValueAsString(img, x, y));
+			}
 		}
+//		String s = selectedChannels.get(0).getValueAsString(img, x, y);
+//		for (int i = 1; i < selectedChannels.size(); i++) {
+//			s += (", " + selectedChannels.get(i).getValueAsString(img, x, y));
+//		}
 		return s;
 	}
 

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/QuPathGUI.java
@@ -793,10 +793,7 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 		if (path == null || path.trim().length() == 0)
 			return null;
 		File dir = new File(path);
-		if (dir.isDirectory()) {
-			return dir;
-		}
-		return null;
+		return dir;
 	}
 	
 	
@@ -1664,11 +1661,20 @@ public class QuPathGUI implements ModeWrapper, ImageDataWrapper<BufferedImage>, 
 		});
 		
 		viewer.getView().addEventFilter(ScrollEvent.ANY, e -> {
-			if (!PathPrefs.getUseScrollGestures() || e.isShiftDown() || e.isShortcutDown())
+			if (e.isInertia()) {
+				e.consume();
 				return;
+			}
+			if (e.getTouchCount() == 0 && (!PathPrefs.getUseScrollGestures()) || e.isShiftDown() || e.isShortcutDown()) {
+				return;
+			}
+			// Swallow the event if we're using a touch screen & not with the move tool selected
+			if (e.getTouchCount() != 0 && getMode() != Modes.MOVE) {
+				e.consume();
+				return;
+			}
 			// TODO: Note: When e.isInertia() == TRUE on OSX, the results are quite annoyingly 'choppy', with 0 x,y movements interspersed with 'true' movements
 //			logger.debug("Delta: " + e.getDeltaX() + ", " + e.getDeltaY() + " - " + e.isInertia());
-			
 			double dx = e.getDeltaX() * viewer.getDownsampleFactor();
 			double dy = e.getDeltaY() * viewer.getDownsampleFactor();
 			

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/commands/BrightnessContrastCommand.java
@@ -679,8 +679,13 @@ public class BrightnessContrastCommand implements PathCommand, ImageDataChangeLi
 	public void updateTable() {
 		if (!isInitialized())
 			return;
-		if (imageDisplay == null)
+		// Reset any buffers for images currently open (used to cache floating point values)
+		for (ChannelDisplayInfo info :table.getItems())
+			info.resetBuffers();
+		// Clear the table
+		if (imageDisplay == null) {
 			table.getItems().clear();
+		}
 		else if (table.getItems().equals(imageDisplay.getAvailableChannels()))
 			table.refresh();
 		else

--- a/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/ProjectBrowser.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/gui/panels/ProjectBrowser.java
@@ -1040,7 +1040,7 @@ public class ProjectBrowser implements ImageDataChangeListener<BufferedImage> {
 				setGraphic(null);
 				return;
 			}
-			
+
 			ProjectImageEntry<?> entry = item instanceof ProjectImageEntry ? (ProjectImageEntry<?>)item : null;
 			if (isCurrentImage(entry))
 				setStyle("-fx-font-weight: bold; -fx-font-family: arial");
@@ -1050,7 +1050,7 @@ public class ProjectBrowser implements ImageDataChangeListener<BufferedImage> {
 				setStyle("-fx-font-style: italic; -fx-font-family: arial");
 			
 			if (entry == null) {
-				setText(item.toString());
+				setText(item.toString() + " (" + getTreeItem().getChildren().size() + ")");
 				tooltip.setText(item.toString());
 				setTooltip(tooltip);
 				setGraphic(null);


### PR DESCRIPTION
Includes fixes for:
* Touchscreen bugs https://github.com/qupath/qupath/issues/188
* The order of the intensity values under the cursor shown in the bottom right of the viewer might be different from expected after toggling channels on/off in multichannel fluorescence images
* Memory leak when retaining `ImageDisplay` buffers after switching between images

Also now shows the number of images in each category in the project browser.