### PR TITLE
Small changes for external use of methods, and gradle fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ You should then start a command prompt, find your way to the directory containin
 ./gradlew.bat createPackage -Ppackager=/path/to/jpackage
 ```
 
-for Windows, or
+for Windows
 
 ```
-./gradlew createPackage -Ppackager=/path/to/jpackage
+gradlew.bat createPackage -Ppackager=/path/to/jpackage
 ```
 
 for MacOS and Linux.

--- a/build.gradle
+++ b/build.gradle
@@ -437,7 +437,7 @@ task createPackage(dependsOn:createRuntime, type:Exec) {
     params << '--app-version' << qupathVersion.replace('-SNAPSHOT', '')
         
     // Not entirely clear this is effective...?
-    params << '--strip-native-commands'
+//    params << '--strip-native-commands' This fails in Java11 on windows
 
     // Try to find the icon
     def pathIcon = Paths.get(

--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ allprojects {
   dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.3'
     testImplementation group: 'junit', name: 'junit', version:'4.12'
+    implementation group:'org.slf4j', name: 'slf4j-api'
   }
 }
 

--- a/qupath-core/src/main/java/qupath/lib/objects/PathAnnotationObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathAnnotationObject.java
@@ -49,7 +49,7 @@ public class PathAnnotationObject extends PathROIObject {
 		super();
 	}
 
-	PathAnnotationObject(ROI pathROI) {
+	public PathAnnotationObject(ROI pathROI) {
 		super(pathROI, null);
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/objects/PathDetectionObject.java
+++ b/qupath-core/src/main/java/qupath/lib/objects/PathDetectionObject.java
@@ -68,7 +68,7 @@ public class PathDetectionObject extends PathROIObject {
 		super(pathROI, pathClass);
 	}
 	
-	PathDetectionObject(ROI pathROI) {
+	public PathDetectionObject(ROI pathROI) {
 		this(pathROI, null);
 	}
 	

--- a/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
@@ -23,19 +23,19 @@
 
 package qupath.lib.roi;
 
-import java.awt.Shape;
+import qupath.lib.common.GeneralTools;
+import qupath.lib.geom.Point2;
+import qupath.lib.roi.interfaces.PathArea;
+import qupath.lib.roi.interfaces.ROI;
+import qupath.lib.roi.interfaces.ROIWithHull;
+import qupath.lib.roi.interfaces.TranslatableROI;
+import qupath.lib.rois.measure.ConvexHull;
+
+import java.awt.*;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.List;
-
-import qupath.lib.common.GeneralTools;
-import qupath.lib.geom.Point2;
-import qupath.lib.roi.interfaces.PathArea;
-import qupath.lib.roi.interfaces.ROIWithHull;
-import qupath.lib.roi.interfaces.ROI;
-import qupath.lib.roi.interfaces.TranslatableROI;
-import qupath.lib.rois.measure.ConvexHull;
 
 
 /**

--- a/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/PolygonROI.java
@@ -86,7 +86,7 @@ public class PolygonROI extends AbstractPathAreaROI implements ROIWithHull, Tran
 //		vertices.close();
 	}
 	
-	PolygonROI(List<Point2> points, int c, int z, int t) {
+	public PolygonROI(List<Point2> points, int c, int z, int t) {
 		super(c, z, t);
 //		vertices = VerticesFactory.createMutableVertices(points.size()+1);
 //		setPoints(points);

--- a/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
+++ b/qupath-core/src/main/java/qupath/lib/roi/RectangleROI.java
@@ -58,7 +58,7 @@ public class RectangleROI extends AbstractPathBoundedROI implements PathArea, Se
 		super(x, y, c, z, t);
 	}
 
-	RectangleROI(double x, double y, double width, double height) {
+	public RectangleROI(double x, double y, double width, double height) {
 		this(x, y, width, height, -1, 0, 0);
 	}
 

--- a/qupath-extension-processing/src/main/java/qupath/imagej/plugins/ImageJMacroRunner.java
+++ b/qupath-extension-processing/src/main/java/qupath/imagej/plugins/ImageJMacroRunner.java
@@ -201,7 +201,7 @@ public class ImageJMacroRunner extends AbstractPlugin<BufferedImage> {
 
 
 
-	static void runMacro(final ParameterList params, final ImageData<BufferedImage> imageData, final ImageDisplay imageDisplay, final PathObject pathObject, final String macroText) {
+	public static void runMacro(final ParameterList params, final ImageData<BufferedImage> imageData, final ImageDisplay imageDisplay, final PathObject pathObject, final String macroText) {
 //		if (!SwingUtilities.isEventDispatchThread()) {
 //			SwingUtilities.invokeLater(() -> runMacro(params, imageData, imageDisplay, pathObject, macroText));
 //			return;

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ChannelDisplayInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ChannelDisplayInfo.java
@@ -23,11 +23,6 @@
 
 package qupath.lib.display;
 
-import java.awt.image.BufferedImage;
-import java.awt.image.ColorModel;
-import java.awt.image.IndexColorModel;
-import java.text.DecimalFormat;
-
 import qupath.lib.awt.color.ColorToolsAwt;
 import qupath.lib.awt.color.ColorTransformerAWT;
 import qupath.lib.color.ColorDeconvolutionHelper;
@@ -37,6 +32,11 @@ import qupath.lib.color.ColorTransformer.ColorTransformMethod;
 import qupath.lib.common.ColorTools;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.IndexColorModel;
+import java.text.DecimalFormat;
 
 /**
  * Interface used to control the display of single channels of image data, where

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ChannelDisplayInfo.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ChannelDisplayInfo.java
@@ -942,7 +942,7 @@ public interface ChannelDisplayInfo {
 		}
 				
 
-		void setLUTColor(int rgb) {
+		public void setLUTColor(int rgb) {
 			setLUTColor(
 					ColorTools.red(rgb),
 					ColorTools.green(rgb),

--- a/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
+++ b/qupath-gui-fx/src/main/java/qupath/lib/display/ImageDisplay.java
@@ -641,7 +641,7 @@ public class ImageDisplay extends AbstractImageRenderer {
 	 * 
 	 * @return
 	 */
-	private String toJSON() {
+	public String toJSON() {
 		return toJSON(false);
 	}
 	
@@ -676,7 +676,7 @@ public class ImageDisplay extends AbstractImageRenderer {
 	 * 
 	 * @param json
 	 */
-	void updateFromJSON(final String json) {
+	public void updateFromJSON(final String json) {
 		Gson gson = new Gson();
 		Type type = new TypeToken<List<JsonHelperChannelInfo>>(){}.getType();
 		List<JsonHelperChannelInfo> helperList = gson.fromJson(json, type);


### PR DESCRIPTION
Hi, 
Using Gradle 5.2 and Jpackager 11.0.2 I needed to make a few modifications to the build.gradle file. 
1. add slf4j dependency. While the initial `gradlew.bat` run worked. It failed after I cleaned my .m2 folder to force a clean setup of gradle. Then IntelliJ complained that slf4j was not available

2. Removed  `params << '--strip-native-commands'` This fails in with the Windows Java 11.0.2 Packager on windows with a 'not recognized parameter.

The other modifications make a few methods `public` so that I can use them within an extension. I could have my extension be a subproject of qupath to avoid this, but I am hoping to keep it independent for now if that's OK.

There is a last modification that simply corrects a typo in the readme file, on the windows packaging instructions. 
Hope these modifications are OK. 

All the best

Oli