### PR TITLE
Support publishing to GitHub packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+# This workflow will publish jars to GitHub Packages.
+# Currently, it must be triggered manually and uses Java 11
+# (because there is no requirement for jpackage).
+
+name: Publish to GitHub Packages
+
+on: [workflow_dispatch]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt-hotspot'
+      - name: Publish package
+        run: ./gradlew publish -P toolchain=11
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/buildSrc/src/main/groovy/qupath.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/qupath.java-conventions.gradle
@@ -5,12 +5,21 @@
 
 plugins {
     id 'java'
+    id 'maven-publish'
 }
 
 java {
     // TODO: Support command line toolchain specification
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(16)
+    def version = project.findProperty('toolchain')
+    if (!version)
+        version = 16
+    else if (version.strip() == 'skip')
+        version = null
+    if (version != null) {
+        logger.info("Setting toolchain to {}", version)
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(version)
+        }
     }
     withSourcesJar()
     withJavadocJar()
@@ -76,4 +85,35 @@ if (!strictJavadoc) {
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
+}
+
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/petebankhead/qupath")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+
+    publications {
+        gpr(MavenPublication) {
+            groupId = 'io.github.qupath'
+            from components.java
+
+            pom {
+                licenses {
+                    license {
+                        name = 'GNU General Public License, Version 3'
+                        url = 'https://www.gnu.org/licenses/gpl-3.0.txt'
+                    }
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Also introduce -P toolchain=skip option to use the current jdk, or -P toolchain=11 to use Java 11 etc.